### PR TITLE
fix(webhook): configure sideEffects to avoid error on dry run

### DIFF
--- a/charts/k8svaultwebhook/templates/mutatingwebhook.yaml
+++ b/charts/k8svaultwebhook/templates/mutatingwebhook.yaml
@@ -38,6 +38,7 @@ items:
         name: {{ template "k8s-vault-webhook.fullname" . }}
         path: /secret
       caBundle: {{ b64enc $ca.Cert }}
+    sideEffects: NoneOnDryRun
     rules:
     - operations:
       - CREATE


### PR DESCRIPTION
Avoid error on `kubectl diff` 

```
kustomize build . | kubectl diff -f -
Error from server (BadRequest): admission webhook "secrets.k8svaultwebhook.webhook" does not support dry run
```

see https://kubernetes.io/blog/2019/01/14/apiserver-dry-run-and-kubectl-diff/#how-to-enable-it